### PR TITLE
Add HTML linting workflow

### DIFF
--- a/.github/workflows/htmlhint.yml
+++ b/.github/workflows/htmlhint.yml
@@ -1,0 +1,16 @@
+name: HTMLHint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  htmlhint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npx htmlhint admin.html index.html

--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -1,0 +1,11 @@
+{
+  "tagname-lowercase": true,
+  "attr-lowercase": true,
+  "attr-value-double-quotes": true,
+  "doctype-first": false,
+  "tag-pair": true,
+  "spec-char-escape": true,
+  "id-unique": true,
+  "src-not-empty": true,
+  "attr-no-duplication": true
+}

--- a/README.md
+++ b/README.md
@@ -701,6 +701,11 @@ function dumpAllData() {
 4. Push to the branch (`git push origin feature/AmazingFeature`)
 5. Open a Pull Request
 
+
+## Development
+
+GitHub Actions automatically lint the HTML pages using [HTMLHint](https://github.com/htmlhint/HTMLHint). The workflow runs `npx htmlhint admin.html index.html` on each push.
+
 ## 📝 ライセンス
 
 MIT License - 詳細は [LICENSE](LICENSE) ファイルをご確認ください。

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "dormitory-management-system",
+  "version": "1.0.0",
+  "description": "- **CDN使用**: 外部ライブラリの高速読み込み\r - **レイジーローディング**: 必要時のみデータ読み込み\r - **メモリ管理**: 効率的なデータ構造とガベージコレクション\r - **圧縮**: Gzip圧縮対応（GitHub Pages自動）\r - **キャッシュ活用**: ブラウザキャッシュでリピート訪問高速化",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "htmlhint": "^0.16.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add HTMLHint GitHub Actions workflow
- create `.htmlhintrc` with common recommended rules
- document HTML linting workflow in `README.md`
- initialize `package.json` with dev dependency for `htmlhint`

## Testing
- `npm install --save-dev htmlhint` *(fails: 403 Forbidden)*
- `npx htmlhint admin.html index.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6850bf7f5ec883268e1f674263734e03